### PR TITLE
Fetch rockets data

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,13 +1,19 @@
 import React from 'react';
+import { useDispatch } from 'react-redux';
 import { Route, Routes } from 'react-router-dom';
+import { fetchRocketsData } from './redux/Rockets/rocketSlice';
 import Navbar from './components/Navbar';
+import Rockets from './components/rockets/Rockets';
 
 function App() {
+  const dispatch = useDispatch();
+  dispatch(fetchRocketsData());
+
   return (
     <div>
       <Navbar />
       <Routes>
-        <Route path="/" element={<p>Hello from rockets!</p>} />
+        <Route path="/" element={<Rockets />} />
         <Route path="/missions" element={<p>Hello from missions!</p>} />
         <Route path="/profile" element={<p>Hello from profile!</p>} />
       </Routes>

--- a/src/components/rockets/Rockets.jsx
+++ b/src/components/rockets/Rockets.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Rockets = () => (
+  <div className="rockets">Rockets</div>
+);
+
+export default Rockets;

--- a/src/redux/Rockets/rocketSlice.js
+++ b/src/redux/Rockets/rocketSlice.js
@@ -1,14 +1,59 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 
-const initialState = [0];
+const initialState = {
+  rocketsArray: [],
+  loading: false,
+};
+
+export const FETCH_ROCKETS_DATA = 'space_traverlers/rockets/FETCH_DATA';
 
 export const rocketSlice = createSlice({
-  name: 'counter',
+  name: 'rockets',
   initialState,
   reducers: {
-  // Do stuff here
-  },
+    initRocketsData(state, action) {
+      return {
+        ...state,
+        rocketsArray: action.payload,
+      };
+    },
 
+    setLoading(state, action) {
+      return {
+        ...state,
+        loading: action.payload,
+      };
+    },
+  },
 });
+
+export const { setLoading, initRocketsData } = rocketSlice.actions;
+
+export const fetchRocketsData = createAsyncThunk(FETCH_ROCKETS_DATA,
+  async (_, thunkApi) => {
+    const state = thunkApi.getState();
+    if (state.rockets.loading) {
+      return null;
+    }
+
+    thunkApi.dispatch(setLoading(true));
+    const response = await fetch('https://api.spacexdata.com/v3/rockets', {
+      method: 'GET',
+      header: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    const responseJSON = await response.json();
+    const fetchedData = responseJSON.map((data) => ({
+      id: data.id,
+      name: data.rocket_name,
+      type: data.rocket_type,
+      image: data.flickr_images[0],
+    }));
+    thunkApi.dispatch(initRocketsData(fetchedData));
+    thunkApi.dispatch(setLoading(false));
+    return responseJSON;
+  });
 
 export default rocketSlice.reducer;


### PR DESCRIPTION
This pull request covers the following requirements 

- Fetch data from the Rockets [endpoint](https://api.spacexdata.com/v3/rockets) when the application starts
- Once the data are fetched, dispatch an action to store the selected data in the Redux store:
  -  id
  -  name
  -  type
  -  flickr_images

NOTE: Make sure you only dispatch those actions once and do not add data to store on every re-render.