### PR TITLE
Switch badges for rocket reservation

### DIFF
--- a/src/components/rockets/Rockets.jsx
+++ b/src/components/rockets/Rockets.jsx
@@ -20,7 +20,11 @@ const Rockets = () => {
           <li key={rocket.id} className="rocket">
             <img src={rocket.image} alt="Rocket" />
             <div>{rocket.name}</div>
-            <div>{rocket.desc}</div>
+            <div>
+              {rocket.reserved ? (<span>Reserved</span>) : ''}
+              {' '}
+              {rocket.desc}
+            </div>
             <button type="button" className="reserve-btn" onClick={() => handleReservation(rocket.id, rocket.reserved)}>{rocket.reserved ? 'Cancel Reservation' : 'Reserve Rocket' }</button>
           </li>
         ))


### PR DESCRIPTION
This pull request covers the following requirements

- Rockets that have already been reserved should show a "Reserved" badge and "Cancel reservation" button instead of the default "Reserve rocket" (as per design)
- Use the React conditional rendering syntax:
```
{rocket.reserved && ( 
    // render Cancel Rocket button
)}
```